### PR TITLE
First shot at adding SPM support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 xcuserdata
 xcshareddata
 
+.DS_Store
+.build/
+.swiftpm/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "Turbolinks",
+  platforms: [.iOS(.v10)],
+  products: [
+    .library(
+    name: "Turbolinks",
+    targets: ["Turbolinks"]),
+  ],
+  dependencies: [
+  ],
+  targets: [
+    .target(
+    name: "Turbolinks",
+    dependencies: [],
+    path: "Turbolinks",
+    exclude:["Tests", "Info.plist"],
+    resources: [.copy("WebView.js")]),
+  ]
+)

--- a/Turbolinks/WebView.swift
+++ b/Turbolinks/WebView.swift
@@ -28,8 +28,7 @@ class WebView: WKWebView {
     init(configuration: WKWebViewConfiguration) {
         super.init(frame: CGRect.zero, configuration: configuration)
 
-        let bundle = Bundle(for: type(of: self))
-        let source = try! String(contentsOf: bundle.url(forResource: "WebView", withExtension: "js")!, encoding: String.Encoding.utf8)
+      let source = try! String(contentsOf: Bundle.module.url(forResource: "WebView", withExtension: "js")!, encoding: String.Encoding.utf8)
         let userScript = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
         configuration.userContentController.addUserScript(userScript)
         configuration.userContentController.add(self, name: "turbolinks")


### PR DESCRIPTION
## Adds `Package.swift` file
* Scopes OS to iOS 10 and greater
* Sets custom source dir, `Turbolinks`
* Excludes building `Test/` and `info.plist`, which happen to be hanging out in `Turbolinks` as well.
* Copies `WebView.js` as an unprocessed resource.

## Updates resource load path
* Modifies code that loads `WebView.js` from the bundle to do it from the module instead.